### PR TITLE
feat: 커스텀 Exception 정의 + ExceptionHandler 추가 및 kotest + mockK 셋업 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,9 @@ repositories {
 
 java.sourceCompatibility = JavaVersion.VERSION_11
 
+val kotestVersion by extra { "4.4.3" }
+val springMockkVersion by extra { "3.1.1" }
+
 subprojects {
     group = "kr.mashup.ladder"
 
@@ -34,6 +37,13 @@ subprojects {
         implementation("org.jetbrains.kotlin:kotlin-reflect")
         implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
         testImplementation("org.springframework.boot:spring-boot-starter-test")
+
+        // kotest
+        testImplementation("io.kotest:kotest-runner-junit5:${kotestVersion}")
+        testImplementation("io.kotest:kotest-extensions-spring:${kotestVersion}")
+
+        // Spring MockK
+        testImplementation("com.ninja-squad:springmockk:${springMockkVersion}")
     }
 
     tasks.withType<KotlinCompile> {

--- a/ladder-api/src/main/kotlin/kr/mashup/ladder/common/advice/ControllerExceptionAdvice.kt
+++ b/ladder-api/src/main/kotlin/kr/mashup/ladder/common/advice/ControllerExceptionAdvice.kt
@@ -1,0 +1,41 @@
+package kr.mashup.ladder.common.advice
+
+import kr.mashup.ladder.common.dto.response.ApiResponse
+import kr.mashup.ladder.domain.common.error.ErrorCode
+import kr.mashup.ladder.domain.common.error.model.LadderBaseException
+import kr.mashup.ladder.domain.common.utils.logger
+import org.slf4j.Logger
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class ControllerExceptionAdvice {
+
+    @ExceptionHandler(LadderBaseException::class)
+    private fun handleBaseException(exception: LadderBaseException): ResponseEntity<ApiResponse<Nothing>> {
+        logging(exception)
+        return ResponseEntity.status(exception.errorCode.status)
+            .body(ApiResponse.error(exception.errorCode))
+    }
+
+    private fun logging(exception: LadderBaseException) {
+        if (exception.errorCode.shouldLog) {
+            logger.error(exception.message, exception)
+            return
+        }
+        logger.warn(exception.message, exception)
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(Exception::class)
+    private fun handleInternalServerException(exception: Exception): ApiResponse<Nothing> {
+        logger.error(exception.message, exception)
+        return ApiResponse.error(ErrorCode.UNKNOWN_ERROR)
+    }
+
+    private val logger: Logger = logger()
+
+}

--- a/ladder-api/src/main/kotlin/kr/mashup/ladder/common/dto/response/ApiResponse.kt
+++ b/ladder-api/src/main/kotlin/kr/mashup/ladder/common/dto/response/ApiResponse.kt
@@ -1,16 +1,27 @@
 package kr.mashup.ladder.common.dto.response
 
+import kr.mashup.ladder.domain.common.error.ErrorCode
+
 data class ApiResponse<T>(
     val code: String = "",
-    val message: String = "",
+    val message: String = "", // TODO: message 서버에서 내려줄 건지 여부 확인 필요
     val data: T?,
 ) {
 
     companion object {
         val OK = ApiResponse(data = "OK")
+
         fun <T> ok(data: T): ApiResponse<T> {
             return ApiResponse(
                 data = data
+            )
+        }
+
+        fun error(errorCode: ErrorCode): ApiResponse<Nothing> {
+            return ApiResponse(
+                code = errorCode.code,
+                message = errorCode.message,
+                data = null
             )
         }
     }

--- a/ladder-api/src/main/kotlin/kr/mashup/ladder/common/dto/response/ApiResponse.kt
+++ b/ladder-api/src/main/kotlin/kr/mashup/ladder/common/dto/response/ApiResponse.kt
@@ -4,7 +4,7 @@ import kr.mashup.ladder.domain.common.error.ErrorCode
 
 data class ApiResponse<T>(
     val code: String = "",
-    val message: String = "", // TODO: message 서버에서 내려줄 건지 여부 확인 필요
+    val message: String = "",
     val data: T?,
 ) {
 

--- a/ladder-api/src/test/kotlin/kr/mashup/ladder/common/advice/ControllerExceptionAdviceTest.kt
+++ b/ladder-api/src/test/kotlin/kr/mashup/ladder/common/advice/ControllerExceptionAdviceTest.kt
@@ -1,0 +1,75 @@
+package kr.mashup.ladder.common.advice
+
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.style.FunSpec
+import io.mockk.every
+import kr.mashup.ladder.common.controller.HealthCheckController
+import kr.mashup.ladder.domain.common.error.ErrorCode
+import kr.mashup.ladder.domain.common.error.model.ForbiddenException
+import kr.mashup.ladder.domain.common.error.model.NotFoundException
+import kr.mashup.ladder.domain.common.error.model.UnknownErrorException
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+
+@AutoConfigureMockMvc
+@SpringBootTest
+internal class ControllerExceptionAdviceTest(
+    private val mockMvc: MockMvc,
+
+    @MockkBean
+    private val healthCheckController: HealthCheckController,
+) : FunSpec({
+
+    context("handling LadderBaseException") {
+        test("404 NotFound 예외 발생시 404 status code로 반환된다") {
+            // given
+            every { healthCheckController.health() } throws NotFoundException("해당하는 리소스는 존재하지 않습니다")
+
+            // when & then
+            mockMvc.get("/health")
+                .andExpect { status { isNotFound() } }
+                .andExpect { jsonPath("$.code") { value(ErrorCode.NOT_FOUND.code) } }
+                .andExpect { jsonPath("$.message") { value(ErrorCode.NOT_FOUND.message) } }
+                .andExpect { jsonPath("$.data") { value(null) } }
+        }
+
+        test("403 Forbidden 예외 발생시 403 status code로 반환된다") {
+            // given
+            every { healthCheckController.health() } throws ForbiddenException("해당하는 권한이 존재하지 않습니다")
+
+            // when & then
+            mockMvc.get("/health")
+                .andExpect { status { isForbidden() } }
+                .andExpect { jsonPath("$.code") { value(ErrorCode.FORBIDDEN.code) } }
+                .andExpect { jsonPath("$.message") { value(ErrorCode.FORBIDDEN.message) } }
+                .andExpect { jsonPath("$.data") { value(null) } }
+        }
+
+        test("UnKnownException 발생시 500 에러로 반환된다") {
+            // given
+            every { healthCheckController.health() } throws UnknownErrorException("알 수 없는 에러가 발생하였습니다")
+
+            // when & then
+            mockMvc.get("/health")
+                .andExpect { status { isInternalServerError() } }
+                .andExpect { jsonPath("$.code") { value(ErrorCode.UNKNOWN_ERROR.code) } }
+                .andExpect { jsonPath("$.message") { value(ErrorCode.UNKNOWN_ERROR.message) } }
+                .andExpect { jsonPath("$.data") { value(null) } }
+        }
+    }
+
+    test("따로 지정되지 않은 Exception 이 발생하면 500 에러로 반환한다") {
+        // given
+        every { healthCheckController.health() } throws IllegalArgumentException("알 수 없는 에러가 발생하였습니다")
+
+        // when & then
+        mockMvc.get("/health")
+            .andExpect { status { isInternalServerError() } }
+            .andExpect { jsonPath("$.code") { value(ErrorCode.UNKNOWN_ERROR.code) } }
+            .andExpect { jsonPath("$.message") { value(ErrorCode.UNKNOWN_ERROR.message) } }
+            .andExpect { jsonPath("$.data") { value(null) } }
+    }
+
+})

--- a/ladder-api/src/test/kotlin/kr/mashup/ladder/common/controller/HealthCheckControllerTest.kt
+++ b/ladder-api/src/test/kotlin/kr/mashup/ladder/common/controller/HealthCheckControllerTest.kt
@@ -1,0 +1,28 @@
+package kr.mashup.ladder.common.controller
+
+import io.kotest.core.spec.style.FunSpec
+import kr.mashup.ladder.common.dto.response.ApiResponse
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+
+@AutoConfigureMockMvc
+@SpringBootTest
+internal class HealthCheckControllerTest(
+    private val mockMvc: MockMvc,
+) : FunSpec({
+
+    test("Health Check 200 OK") {
+        // when & then
+        mockMvc.get("/health")
+            .andDo { print() }
+            .andExpect { status { isOk() } }
+            .andExpect {
+                jsonPath("$.code") { isEmpty() }
+                jsonPath("$.message") { isEmpty() }
+                jsonPath("$.data") { value(ApiResponse.OK.data) }
+            }
+    }
+
+})

--- a/ladder-domain/src/main/kotlin/kr/mashup/ladder/domain/common/domain/BaseTimeEntity.kt
+++ b/ladder-domain/src/main/kotlin/kr/mashup/ladder/domain/common/domain/BaseTimeEntity.kt
@@ -1,0 +1,20 @@
+package kr.mashup.ladder.domain.common.domain
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+import javax.persistence.EntityListeners
+import javax.persistence.MappedSuperclass
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+class BaseTimeEntity {
+
+    @CreatedDate
+    lateinit var createdAt: LocalDateTime
+
+    @LastModifiedDate
+    lateinit var updatedAt: LocalDateTime
+
+}

--- a/ladder-domain/src/main/kotlin/kr/mashup/ladder/domain/common/error/ErrorCode.kt
+++ b/ladder-domain/src/main/kotlin/kr/mashup/ladder/domain/common/error/ErrorCode.kt
@@ -6,21 +6,21 @@ package kr.mashup.ladder.domain.common.error
  */
 
 enum class ErrorCode(
-    val status: Int, // TODO: HttpStatus 로 변환 고려
+    val status: Int,
     val code: String,
     val message: String,
     val shouldLog: Boolean,
 ) {
     // common
-    INVALID_REQUEST(status = 400, code = "C001", message = "잘못된 요청", shouldLog = false),
-    UNAUTHORIZED(status = 401, code = "C002", message = "인증 실패", shouldLog = false),
-    FORBIDDEN(status = 403, code = "C003", message = "인가 실패", shouldLog = false),
+    INVALID_REQUEST(status = 400, code = "C001", message = "잘못된 요청입니다", shouldLog = false),
+    UNAUTHORIZED(status = 401, code = "C002", message = "인증에 실패하였습니다 다시 로그인 해주세요", shouldLog = false),
+    FORBIDDEN(status = 403, code = "C003", message = "해당 권한이 존재하지 않습니다", shouldLog = false),
     NOT_FOUND(status = 404, code = "C004", message = "해당하는 리소스는 존재하지 않습니다", shouldLog = false),
     CONFLICT(status = 409, code = "C005", message = "중복된 리소스가 존재합니다", shouldLog = false),
     UNKNOWN_ERROR(status = 500, code = "C006", message = "서버에서 에러가 발생하였습니다 ㅠㅠ", shouldLog = true),
 
     // room
-    ROOM_NOT_FOUND(status = 404, code = "R001", message = "해당하는 방이 존재하지 않습니단", shouldLog = false),
+    ROOM_NOT_FOUND(status = 404, code = "R001", message = "해당하는 방이 존재하지 않습니다", shouldLog = false),
 
     // ...
 }

--- a/ladder-domain/src/main/kotlin/kr/mashup/ladder/domain/common/error/ErrorCode.kt
+++ b/ladder-domain/src/main/kotlin/kr/mashup/ladder/domain/common/error/ErrorCode.kt
@@ -6,20 +6,21 @@ package kr.mashup.ladder.domain.common.error
  */
 
 enum class ErrorCode(
-    val code: String,
     val status: Int, // TODO: HttpStatus 로 변환 고려
+    val code: String,
+    val message: String,
     val shouldLog: Boolean,
 ) {
     // common
-    INVALID_REQUEST("C001", 400, false),
-    UNAUTHORIZED("C002", 401, false),
-    FORBIDDEN("C003", 403, false),
-    NOT_FOUND("C004", 404, false),
-    CONFLICT("C005", 409, false),
-    UNKNOWN_ERROR("C006", 500, true),
+    INVALID_REQUEST(status = 400, code = "C001", message = "잘못된 요청", shouldLog = false),
+    UNAUTHORIZED(status = 401, code = "C002", message = "인증 실패", shouldLog = false),
+    FORBIDDEN(status = 403, code = "C003", message = "인가 실패", shouldLog = false),
+    NOT_FOUND(status = 404, code = "C004", message = "해당하는 리소스는 존재하지 않습니다", shouldLog = false),
+    CONFLICT(status = 409, code = "C005", message = "중복된 리소스가 존재합니다", shouldLog = false),
+    UNKNOWN_ERROR(status = 500, code = "C006", message = "서버에서 에러가 발생하였습니다 ㅠㅠ", shouldLog = true),
 
     // room
-    ROOM_NOT_FOUND("R001", 404, false),
+    ROOM_NOT_FOUND(status = 404, code = "R001", message = "해당하는 방이 존재하지 않습니단", shouldLog = false),
 
     // ...
 }

--- a/ladder-domain/src/main/kotlin/kr/mashup/ladder/domain/common/error/model/LadderBaseException.kt
+++ b/ladder-domain/src/main/kotlin/kr/mashup/ladder/domain/common/error/model/LadderBaseException.kt
@@ -1,0 +1,68 @@
+package kr.mashup.ladder.domain.common.error.model
+
+import kr.mashup.ladder.domain.common.error.ErrorCode
+
+abstract class LadderBaseException(
+    override val message: String,
+    open val errorCode: ErrorCode,
+) : RuntimeException(message)
+
+
+/**
+ * InvalidException
+ * 400 BadRequest
+ */
+data class InvalidRequestException(
+    override val message: String,
+    override val errorCode: ErrorCode = ErrorCode.INVALID_REQUEST,
+) : LadderBaseException(message, errorCode)
+
+
+/**
+ * UnAuthorizedException
+ * 401 UnAuthorized
+ */
+data class UnAuthorizedException(
+    override val message: String,
+    override val errorCode: ErrorCode = ErrorCode.UNAUTHORIZED,
+) : LadderBaseException(message, errorCode)
+
+
+/**
+ * ForbiddenException
+ * 403 Forbidden
+ */
+data class ForbiddenException(
+    override val message: String,
+    override val errorCode: ErrorCode = ErrorCode.FORBIDDEN,
+) : LadderBaseException(message, errorCode)
+
+
+/**
+ * NotFoundException
+ * 404 NotFound
+ */
+data class NotFoundException(
+    override val message: String,
+    override val errorCode: ErrorCode = ErrorCode.NOT_FOUND,
+) : LadderBaseException(message, errorCode)
+
+
+/**
+ * ConflictException
+ * 409 Conflict
+ */
+data class ConflictException(
+    override val message: String,
+    override val errorCode: ErrorCode = ErrorCode.CONFLICT,
+) : LadderBaseException(message, errorCode)
+
+
+/**
+ * UnknownErrorException
+ * 500 InternalServer
+ */
+data class UnknownErrorException(
+    override val message: String,
+    override val errorCode: ErrorCode = ErrorCode.UNKNOWN_ERROR,
+) : LadderBaseException(message, errorCode)

--- a/ladder-domain/src/main/kotlin/kr/mashup/ladder/domain/common/utils/LoggerUtils.kt
+++ b/ladder-domain/src/main/kotlin/kr/mashup/ladder/domain/common/utils/LoggerUtils.kt
@@ -1,0 +1,8 @@
+package kr.mashup.ladder.domain.common.utils
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+inline fun <reified T> T.logger(): Logger {
+    return LoggerFactory.getLogger(T::class.java)
+}

--- a/ladder-domain/src/main/kotlin/kr/mashup/ladder/domain/config/JpaConfig.kt
+++ b/ladder-domain/src/main/kotlin/kr/mashup/ladder/domain/config/JpaConfig.kt
@@ -3,8 +3,10 @@ package kr.mashup.ladder.domain.config
 import kr.mashup.ladder.domain.LadderDomainRoot
 import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.context.annotation.Configuration
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 
+@EnableJpaAuditing
 @Configuration
 @EntityScan(basePackageClasses = [LadderDomainRoot::class])
 @EnableJpaRepositories(basePackageClasses = [LadderDomainRoot::class])

--- a/ladder-domain/src/main/kotlin/kr/mashup/ladder/domain/video/domain/Video.kt
+++ b/ladder-domain/src/main/kotlin/kr/mashup/ladder/domain/video/domain/Video.kt
@@ -1,11 +1,12 @@
 package kr.mashup.ladder.domain.video.domain
 
+import kr.mashup.ladder.domain.common.domain.BaseTimeEntity
 import java.util.*
 import javax.persistence.Entity
 import javax.persistence.Id
 
 @Entity
-class Video {
+class Video : BaseTimeEntity() {
 
     @Id
     val id: UUID = UUID.randomUUID()


### PR DESCRIPTION
### 변경 사항

### statusCode 별 커스텀 Exception 정의
  -  이 부분 어느 정도로 나눌 건지 의논이 필요해보임!
 
 1. `throw NotFoundException(errorCode = DUPLICATE_EMAIL, message = ... )`  # status code 까지만 분리하고, 세부 내용은 errorCode로 관리
 2. `throw DuplicateEmail(message = ...)` # 완전히 비즈니스적인 Exception 
 3. `throw LadderBaseException(errorCode = DUPLICATE_EMAIL, message = ...)`  # BaseException + errorCode로 관리
  
  
### ExceptionHandler
- CustomException에 대해서만 핸들링 추가해주고, 나머지 필수 파라미터 or BindException 등에 대해서는 아직 정의 X

### kotest + springMockK
- 셋업 및 샘플 코드 작성해뒀어!
- junit5 + mockito 쪽이 더 편할 수도 있어서, junit5 + kotest 이중적으로 가도 괜찮을거 같아
  
 