### PR TITLE
feat: 설정 정보 관리

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -2,6 +2,10 @@ name: 배포 - API
 on:
   workflow_dispatch:
     inputs:
+      branch:
+        description: "브랜치"
+        default: 'develop'
+        required: true
       version:
         description: "버전"
         default: '0.0.1'

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -39,14 +39,6 @@ jobs:
           echo "::set-output name=version::${VERSION}"
         env:
           VERSIONING: ${{ github.event.inputs.version }}
-      - name: Setup secret properties # TODO: 변경 필요 - 임시로 프로퍼티를 생성하는 방식으로 대응 중
-        env:
-          SECRET_KAKAO_TOKEN_CLIENT_ID: ${{secrets.SECRET_KAKAO_TOKEN_CLIENT_ID}}
-          SECRET_KAKAO_TOKEN_CLIENT_SECRET: ${{secrets.SECRET_KAKAO_TOKEN_CLIENT_SECRET}}
-
-          RESOURCE_PWD: ladder-api/src/main/resources
-        run: |
-          echo -e "secret.kakao.token.client-id=$SECRET_KAKAO_TOKEN_CLIENT_ID\nsecret.kakao.token.client-secret=$SECRET_KAKAO_TOKEN_CLIENT_SECRET" > $RESOURCE_PWD/application-secret.properties
       - name: Execute Gradle Jib
         run: ./gradlew :ladder-api:jib -Dimage=${IMAGE} -Dtag=${TAG}
         env:

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -2,10 +2,6 @@ name: 배포 - API
 on:
   workflow_dispatch:
     inputs:
-      branch:
-        description: "브랜치"
-        default: 'develop'
-        required: true
       version:
         description: "버전"
         default: '0.0.1'

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 
 logs/
+application-secret.yml

--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,3 @@ out/
 .vscode/
 
 logs/
-application-secret.yml

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,9 @@ subprojects {
         // Kotlin Logging
         implementation("io.github.microutils:kotlin-logging-jvm:${kotlinLoggingVersion}")
 
+        // Jasypt
+        implementation("com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.4")
+
         // Test
         testImplementation("org.springframework.boot:spring-boot-starter-test")
 

--- a/ladder-api/src/main/resources/application-thirdparty.yml
+++ b/ladder-api/src/main/resources/application-thirdparty.yml
@@ -1,13 +1,8 @@
 kakao:
   token:
     url: https://kauth.kakao.com/oauth/token
-    client-id: ${secret.kakao.token.client-id}
-    client-secret: ${secret.kakao.token.client-secret}
+    client-id: ENC(GyJMgOkFC2b1NcZQRiKCX9LHCj+Ee8KH0qYdaPSt04dE2D9Unb1/iuMskH/e1FUFGOUVeS+pfPLoCaLD/qv8UrTt2icDzjM7a2e8oepXwIk=)
+    client-secret: ENC(AyD+paTypSCBmNa1J58vPRR0LIHAb6Lu6HaNl52uOe3jbkjwMlyQXxF2iFyczwIMW2vJ3l0xLVNfoVbvONJ7sEWVLkgXG4lD1AA8uPgocfU=)
     grant-type: authorization_code
   profile:
     url: https://kapi.kakao.com/v2/user/me
-youtube:
-  video:
-    url: https://www.googleapis.com/youtube/v3/videos
-    key: ${secret.youtube.video.key}
-    part: id,snippet,contentDetails

--- a/ladder-api/src/main/resources/application-thirdparty.yml
+++ b/ladder-api/src/main/resources/application-thirdparty.yml
@@ -1,8 +1,38 @@
 kakao:
   token:
     url: https://kauth.kakao.com/oauth/token
-    client-id: ENC(GyJMgOkFC2b1NcZQRiKCX9LHCj+Ee8KH0qYdaPSt04dE2D9Unb1/iuMskH/e1FUFGOUVeS+pfPLoCaLD/qv8UrTt2icDzjM7a2e8oepXwIk=)
-    client-secret: ENC(AyD+paTypSCBmNa1J58vPRR0LIHAb6Lu6HaNl52uOe3jbkjwMlyQXxF2iFyczwIMW2vJ3l0xLVNfoVbvONJ7sEWVLkgXG4lD1AA8uPgocfU=)
     grant-type: authorization_code
   profile:
     url: https://kapi.kakao.com/v2/user/me
+---
+spring.config:
+  activate:
+    on-profile: local
+kakao:
+  token:
+    client-id: ENC(GyJMgOkFC2b1NcZQRiKCX9LHCj+Ee8KH0qYdaPSt04dE2D9Unb1/iuMskH/e1FUFGOUVeS+pfPLoCaLD/qv8UrTt2icDzjM7a2e8oepXwIk=)
+    client-secret: ENC(AyD+paTypSCBmNa1J58vPRR0LIHAb6Lu6HaNl52uOe3jbkjwMlyQXxF2iFyczwIMW2vJ3l0xLVNfoVbvONJ7sEWVLkgXG4lD1AA8uPgocfU=)
+---
+spring.config:
+  activate:
+    on-profile: test
+kakao:
+  token:
+    client-id: undefined
+    client-secret: undefined
+---
+spring.config:
+  activate:
+    on-profile: dev
+kakao:
+  token:
+    client-id: ENC(GyJMgOkFC2b1NcZQRiKCX9LHCj+Ee8KH0qYdaPSt04dE2D9Unb1/iuMskH/e1FUFGOUVeS+pfPLoCaLD/qv8UrTt2icDzjM7a2e8oepXwIk=)
+    client-secret: ENC(AyD+paTypSCBmNa1J58vPRR0LIHAb6Lu6HaNl52uOe3jbkjwMlyQXxF2iFyczwIMW2vJ3l0xLVNfoVbvONJ7sEWVLkgXG4lD1AA8uPgocfU=)
+---
+spring.config:
+  activate:
+    on-profile: prod
+kakao:
+  token:
+    client-id: ENC(GyJMgOkFC2b1NcZQRiKCX9LHCj+Ee8KH0qYdaPSt04dE2D9Unb1/iuMskH/e1FUFGOUVeS+pfPLoCaLD/qv8UrTt2icDzjM7a2e8oepXwIk=)
+    client-secret: ENC(AyD+paTypSCBmNa1J58vPRR0LIHAb6Lu6HaNl52uOe3jbkjwMlyQXxF2iFyczwIMW2vJ3l0xLVNfoVbvONJ7sEWVLkgXG4lD1AA8uPgocfU=)

--- a/ladder-api/src/main/resources/application.yml
+++ b/ladder-api/src/main/resources/application.yml
@@ -3,8 +3,6 @@ spring.config:
   import:
     - classpath:/application-domain.yml
     - classpath:/application-thirdparty.yml
-    - optional:classpath:/application-secret.yml
-    - optional:classpath:/application-secret.properties
 
 server:
   port: 9000

--- a/ladder-api/src/main/resources/application.yml
+++ b/ladder-api/src/main/resources/application.yml
@@ -3,6 +3,7 @@ spring.config:
   import:
     - classpath:/application-domain.yml
     - classpath:/application-thirdparty.yml
+    - optional:classpath:/application-secret.yml
 
 server:
   port: 9000

--- a/ladder-domain/src/main/kotlin/kr/mashup/ladder/domain/config/jasypt/JasyptConfig.kt
+++ b/ladder-domain/src/main/kotlin/kr/mashup/ladder/domain/config/jasypt/JasyptConfig.kt
@@ -1,0 +1,9 @@
+package kr.mashup.ladder.domain.config.jasypt
+
+import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties
+import org.springframework.context.annotation.Configuration
+
+
+@Configuration
+@EnableEncryptableProperties
+class JasyptConfig

--- a/ladder-domain/src/test/kotlin/kr/mashup/ladder/domain/config/JasyptConfigTest.kt
+++ b/ladder-domain/src/test/kotlin/kr/mashup/ladder/domain/config/JasyptConfigTest.kt
@@ -1,0 +1,30 @@
+package kr.mashup.ladder.domain.config
+
+import org.jasypt.encryption.StringEncryptor
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.TestConstructor
+
+/**
+ * Run > Edit Configurations > Configuration > Environment variables > 'JASYPT_ENCRYPTOR_PASSWORD={암호화키}' 입력
+ */
+@Disabled("암호화, 복호화 결과 확인을 위한 테스트이므로 비활성화")
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@SpringBootTest
+class JasyptConfigTest(
+    private val stringEncryptor: StringEncryptor,
+) {
+    @ParameterizedTest
+    @ValueSource(strings = ["decrypted"])
+    fun encrypt(decrypted: String) {
+        print(stringEncryptor.encrypt(decrypted))
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["encrypted"])
+    fun decrypt(encrypted: String) {
+        print(stringEncryptor.decrypt(encrypted))
+    }
+}


### PR DESCRIPTION
https://github.com/mash-up-kr/ladder_backend_spring/issues/31

- https://github.com/mash-up-kr/ladder_backend_infra/pull/1
- 설정 정보 관리하기 위해 jasypt + sealed secrets 2가지를 활용하는 방안을 생각해봤는데 위 이슈에 정리해뒀으니 참고!
- 일단 ladder-api 쪽만 수정해봐서 괜찮다 싶으면 ladder-search 쪽도 적용해야 할 듯
- 괜찮아 보이면 배포해보려고 하는데 어때? (아직 배포 안해봐서 잘 되는지는 모름 ㅎ)