### PR TITLE
feat: 재생목록 항목 등록시 dominant color 값 포함

### DIFF
--- a/ladder-api/src/main/kotlin/kr/mashup/ladder/playlist/dto/PlaylistItemDto.kt
+++ b/ladder-api/src/main/kotlin/kr/mashup/ladder/playlist/dto/PlaylistItemDto.kt
@@ -9,6 +9,7 @@ data class PlaylistItemDto(
     val title: String,
     val thumbnail: String,
     val duration: Int,
+    val dominantColor: String?,
 ) {
     companion object {
         fun of(item: PlaylistItem): PlaylistItemDto {
@@ -19,6 +20,7 @@ data class PlaylistItemDto(
                 title = item.title,
                 thumbnail = item.thumbnail,
                 duration = item.duration,
+                dominantColor = item.dominantColor,
             )
         }
     }

--- a/ladder-api/src/main/kotlin/kr/mashup/ladder/room/dto/request/RoomAddPlaylistItemRequest.kt
+++ b/ladder-api/src/main/kotlin/kr/mashup/ladder/room/dto/request/RoomAddPlaylistItemRequest.kt
@@ -10,6 +10,7 @@ data class RoomAddPlaylistItemRequest(
     val title: String,
     val thumbnail: String,
     val duration: Int,
+    val dominantColor: String?,
 ) {
     fun toEntity(playlist: Playlist): PlaylistItem {
         return PlaylistItem(
@@ -17,7 +18,8 @@ data class RoomAddPlaylistItemRequest(
             videoId = videoId,
             title = title,
             thumbnail = thumbnail,
-            duration = duration
+            duration = duration,
+            dominantColor = dominantColor,
         )
     }
 

--- a/ladder-api/src/main/kotlin/kr/mashup/ladder/room/dto/request/RoomSendPlaylistItemRequestRequest.kt
+++ b/ladder-api/src/main/kotlin/kr/mashup/ladder/room/dto/request/RoomSendPlaylistItemRequestRequest.kt
@@ -10,6 +10,7 @@ data class RoomSendPlaylistItemRequestRequest(
     val title: String,
     val thumbnail: String,
     val duration: Int,
+    val dominantColor: String?,
 ) {
     fun toEntity(playlist: Playlist): PlaylistItem {
         return PlaylistItem(
@@ -17,7 +18,8 @@ data class RoomSendPlaylistItemRequestRequest(
             videoId = videoId,
             title = title,
             thumbnail = thumbnail,
-            duration = duration
+            duration = duration,
+            dominantColor = dominantColor,
         )
     }
 

--- a/ladder-api/src/main/kotlin/kr/mashup/ladder/room/dto/response/RoomPlaylistItemAddResponse.kt
+++ b/ladder-api/src/main/kotlin/kr/mashup/ladder/room/dto/response/RoomPlaylistItemAddResponse.kt
@@ -9,6 +9,7 @@ data class RoomPlaylistItemAddResponse(
     val title: String,
     val thumbnail: String,
     val duration: Int,
+    val dominantColor: String?,
 ) {
     companion object {
         fun of(item: PlaylistItem): RoomPlaylistItemAddResponse {
@@ -19,6 +20,7 @@ data class RoomPlaylistItemAddResponse(
                 title = item.title,
                 thumbnail = item.thumbnail,
                 duration = item.duration,
+                dominantColor = item.dominantColor,
             )
         }
     }

--- a/ladder-api/src/main/kotlin/kr/mashup/ladder/room/dto/response/RoomPlaylistItemRequestResponse.kt
+++ b/ladder-api/src/main/kotlin/kr/mashup/ladder/room/dto/response/RoomPlaylistItemRequestResponse.kt
@@ -9,6 +9,7 @@ data class RoomPlaylistItemRequestResponse(
     val title: String,
     val thumbnail: String,
     val duration: Int,
+    val dominantColor: String?,
 ) {
     companion object {
         fun of(item: PlaylistItem): RoomPlaylistItemRequestResponse {
@@ -19,6 +20,7 @@ data class RoomPlaylistItemRequestResponse(
                 title = item.title,
                 thumbnail = item.thumbnail,
                 duration = item.duration,
+                dominantColor = item.dominantColor,
             )
         }
     }

--- a/ladder-api/src/test/kotlin/kr/mashup/ladder/room/RoomAcceptanceTest.kt
+++ b/ladder-api/src/test/kotlin/kr/mashup/ladder/room/RoomAcceptanceTest.kt
@@ -379,6 +379,7 @@ class RoomAcceptanceTest : AcceptanceTest() {
                 { assertThat(response.data!!.title).isEqualTo(request.title) },
                 { assertThat(response.data!!.thumbnail).isEqualTo(request.thumbnail) },
                 { assertThat(response.data!!.duration).isEqualTo(request.duration) },
+                { assertThat(response.data!!.dominantColor).isEqualTo(request.dominantColor) },
             )
 
             return response.data!!
@@ -444,6 +445,7 @@ class RoomAcceptanceTest : AcceptanceTest() {
                 { assertThat(responses.map { it.data!!.title }).allMatch { it == request.title } },
                 { assertThat(responses.map { it.data!!.thumbnail }).allMatch { it == request.thumbnail } },
                 { assertThat(responses.map { it.data!!.duration }).allMatch { it == request.duration } },
+                { assertThat(responses.map { it.data!!.dominantColor }).allMatch { it == request.dominantColor } },
             )
         }
     }

--- a/ladder-api/src/test/kotlin/kr/mashup/ladder/room/RoomFixture.kt
+++ b/ladder-api/src/test/kotlin/kr/mashup/ladder/room/RoomFixture.kt
@@ -19,7 +19,8 @@ class RoomFixture {
                 videoId = "LqfimuFAFJ8",
                 title = "라일락",
                 duration = 229,
-                thumbnail = "https://i.ytimg.com/vi/LqfimuFAFJ8/maxresdefault.jpg"
+                thumbnail = "https://i.ytimg.com/vi/LqfimuFAFJ8/maxresdefault.jpg",
+                dominantColor = "#FFFFFF",
             )
         }
 
@@ -29,7 +30,8 @@ class RoomFixture {
                 videoId = "LqfimuFAFJ8",
                 title = "라일락",
                 duration = 229,
-                thumbnail = "https://i.ytimg.com/vi/LqfimuFAFJ8/maxresdefault.jpg"
+                thumbnail = "https://i.ytimg.com/vi/LqfimuFAFJ8/maxresdefault.jpg",
+                dominantColor = "#FFFFFF",
             )
         }
 

--- a/ladder-domain/src/main/kotlin/kr/mashup/ladder/domain/playlistitem/domain/PlaylistItem.kt
+++ b/ladder-domain/src/main/kotlin/kr/mashup/ladder/domain/playlistitem/domain/PlaylistItem.kt
@@ -2,7 +2,13 @@ package kr.mashup.ladder.domain.playlistitem.domain
 
 import kr.mashup.ladder.domain.common.domain.BaseEntity
 import kr.mashup.ladder.domain.playlist.domain.Playlist
-import javax.persistence.*
+import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+import javax.persistence.FetchType
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
 
 @Table(name = "playlist_item")
 @Entity
@@ -14,6 +20,7 @@ class PlaylistItem(
     title: String,
     thumbnail: String,
     duration: Int,
+    dominantColor: String?,
 ) : BaseEntity() {
     var videoId: String = videoId
         protected set
@@ -22,6 +29,8 @@ class PlaylistItem(
     var thumbnail: String = thumbnail
         protected set
     var duration: Int = duration
+        protected set
+    var dominantColor: String? = dominantColor
         protected set
 
     @Enumerated(value = EnumType.STRING)


### PR DESCRIPTION
```
준석아 아까 썸내일 얘기 정리해줄게~! 
프론트에서 nextjs 서버이용해서 썸네일 추출이 가능해졋어!
그래서 곡 추가시 서버에 대표 color값을 넘겨줄수 있을거같아! 그럼 서버에서 color값 저장하고 플레이리스트 내려줄때 같이 주면 될듯~!
```